### PR TITLE
Fix undefined name `self` in mcts.py

### DIFF
--- a/src/mcts.py
+++ b/src/mcts.py
@@ -150,7 +150,7 @@ class MCTS_Params:
         self.method = 'ai'
         self.using_prior_for_exploration = False
 
-def active_inference_mcts(model, frame, params, o_shape=(64,64,1)):
+def active_inference_mcts(model, frame, params, o_shape=(64,64,1), pi_dim=4):
     states_explored = 0
     all_paths = [] # For debugging.
     all_paths_G = [] # For debugging.
@@ -170,7 +170,7 @@ def active_inference_mcts(model, frame, params, o_shape=(64,64,1)):
         if calc_threshold(root.Qpi, axis=0) > params.threshold:
             if params.verbose: print('Decision in phase A Qpi:',root.Qpi, calc_threshold(root.Qpi,axis=0))
             MCTS_choices = root.Qpi
-            return [np.random.choice(self.pi_dim, p=root.Qpi)], 0, states_explored, all_paths, all_paths_G
+            return [np.random.choice(pi_dim, p=root.Qpi)], 0, states_explored, all_paths, all_paths_G
 
     root.expand(use_means=params.use_means)
 


### PR DESCRIPTION
Hey, fixed undefined name `self` and added missing `pi_dim` parameter.

`deep-active-inference-mc/src/mcts.py:173:38: F821 undefined name 'self'`